### PR TITLE
Add missing implementation of getAdid method on iOS

### DIFF
--- a/ios/Classes/AdjustSdk.m
+++ b/ios/Classes/AdjustSdk.m
@@ -99,6 +99,8 @@ static NSString * const CHANNEL_API_NAME = @"com.adjust.sdk/api";
     } else if ([@"isEnabled" isEqualToString:call.method]) {
         BOOL isEnabled = [Adjust isEnabled];
         result(@(isEnabled));
+    } else if ([@"getAdid" isEqualToString:call.method]) {
+        result([Adjust adid]);
     } else {
         result(FlutterMethodNotImplemented);
     }

--- a/lib/adjust.dart
+++ b/lib/adjust.dart
@@ -16,7 +16,8 @@ import 'package:adjust_sdk/adjust_attribution.dart';
 
 class Adjust {
   static const String _sdkPrefix = 'flutter4.18.0';
-  static const MethodChannel _channel = const MethodChannel('com.adjust.sdk/api');
+  static const MethodChannel _channel =
+      const MethodChannel('com.adjust.sdk/api');
 
   static void start(AdjustConfig config) {
     config.sdkPrefix = _sdkPrefix;
@@ -68,6 +69,7 @@ class Adjust {
     return isEnabled;
   }
 
+  /// Return value could be `null`
   static Future<String> getAdid() async {
     final String adid = await _channel.invokeMethod('getAdid');
     return adid;
@@ -111,11 +113,13 @@ class Adjust {
   }
 
   static void addSessionCallbackParameter(String key, String value) {
-    _channel.invokeMethod('addSessionCallbackParameter', {'key': key, 'value': value});
+    _channel.invokeMethod(
+        'addSessionCallbackParameter', {'key': key, 'value': value});
   }
 
   static void addSessionPartnerParameter(String key, String value) {
-    _channel.invokeMethod('addSessionPartnerParameter', {'key': key, 'value': value});
+    _channel.invokeMethod(
+        'addSessionPartnerParameter', {'key': key, 'value': value});
   }
 
   static void removeSessionCallbackParameter(String key) {
@@ -135,7 +139,8 @@ class Adjust {
   }
 
   static void trackAdRevenue(String source, String payload) {
-    _channel.invokeMethod('trackAdRevenue', {'source': source, 'payload': payload});
+    _channel
+        .invokeMethod('trackAdRevenue', {'source': source, 'payload': payload});
   }
 
   // For testing purposes only. Do not use in production.


### PR DESCRIPTION
The method `getAdid` was missing in the native iOS plugin code which causes to result in a `MissingPluginException`.

Exception:
```
flutter: Caught error: MissingPluginException(No implementation found for method getAdid on channel com.adjust.sdk/api)
flutter: #0      MethodChannel.invokeMethod 
package:flutter/…/services/platform_channel.dart:314
<asynchronous suspension>
#1      Adjust.getAdid 
package:adjust_sdk/adjust.dart:72
<asynchronous suspension>
#2      AdjustTrackingProvider._trackAppStart 
package:tracking/…/providers/adjust.dart:106
<asynchronous suspension>
#3      new AdjustTrackingProvider 
package:tracking/…/providers/adjust.dart:20
#4      createTrackingClient 
package:aym/utils/create_tracking_client.dart:45
#5      AppStateLayer.build.<anonymous closure> 
package:aym/layers/app_state_layer.dart:57
#6      BuilderStateDelegate.initDelegate 
package:provider/src/delegate_widget.dart:249
#7      _DelegateWidgetState._initDelegate 
package:provider/src/delegate_widget.dart:118
#8      _DelegateWidgetState.initState 
package:provider/src/delegate_widget.dart:110
#9      StatefulElement._firstBuild 
package:flutter/…/widgets/framework.dart:4068
#10     ComponentElement.moun<…>
```

![Screenshot 2019-10-05 at 20 52 52](https://user-images.githubusercontent.com/8514706/66267314-b20fd600-e82f-11e9-8030-0ca14cd62cb0.png)

The formatting changes come from a newer flutter version. Just let me know if I should revert them.