### PR TITLE
Fix android build warning when flutter stable(2.10.4)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ rootProject.allprojects {
 }
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 32
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Hi, I build android myapp with installed the latest sdk, then the following warning occurs.

```yaml
Warning: The plugin adjust_sdk requires Android SDK version 32.
One or more plugins require a higher Android SDK version.
Fix this issue by adding the following to myapp/android/app/build.gradle:
android {
  compileSdkVersion 32
  ...
}
```

Flutter version is here.
<details>
<summary> Flutter version 2.10.4</summary>

```yaml
[✓] Flutter (Channel stable, 2.10.4, on macOS 12.3.1 21E258 darwin-arm, locale ja-JP)
    • Flutter version 2.10.4
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision c860cba910 (11 days ago), 2022-03-25 00:23:12 -0500
    • Engine revision 57d3bac3dd
    • Dart version 2.16.2
    • DevTools version 2.9.2
```
</details>

It seems that the PR changed compileSdkVersion 30 to 32. What is purpose to use  compileSdkVersion 32?
- https://github.com/adjust/flutter_sdk/pull/74/commits/da9f54de25fd708fd52316275e01b20aa25a9daf

If you don't have any reasons, I think that you should use same to flutter framework(current is 31).
https://github.com/flutter/flutter/blob/977c35307fec91301973f8b6edd43cf3b617f684/packages/flutter_tools/gradle/flutter.gradle#L33

Thanks.
