### PR TITLE
Fix for App Crashes During JSON Serialization After Updates

### DIFF
--- a/ios/Classes/AdjustSdk.m
+++ b/ios/Classes/AdjustSdk.m
@@ -267,7 +267,7 @@ static NSString * const CHANNEL_API_NAME = @"com.adjust.sdk/api";
             [adjustConfig disableIdfvReading];
         }
     }
-    
+
     // SKAdNetwork attribution
     if ([self isFieldValid:isSkanAttributionEnabled]) {
         if ([isSkanAttributionEnabled boolValue] == NO) {
@@ -419,7 +419,7 @@ static NSString * const CHANNEL_API_NAME = @"com.adjust.sdk/api";
     if (urlString == nil) {
         return;
     }
-    
+
     NSURL *url = [NSURL URLWithString:urlString];
     ADJDeeplink *deeplink = [[ADJDeeplink alloc] initWithDeeplink:url];
     [Adjust processDeeplink:deeplink];
@@ -456,12 +456,12 @@ static NSString * const CHANNEL_API_NAME = @"com.adjust.sdk/api";
     if ([self isFieldValid:adRevenueNetwork]) {
         [adjustAdRevenue setAdRevenueNetwork:adRevenueNetwork];
     }
-    
+
     // ad revenue unit
     if ([self isFieldValid:adRevenueUnit]) {
         [adjustAdRevenue setAdRevenueUnit:adRevenueUnit];
     }
-    
+
     // ad revenue placement
     if ([self isFieldValid:adRevenuePlacement]) {
         [adjustAdRevenue setAdRevenuePlacement:adRevenuePlacement];
@@ -576,13 +576,19 @@ static NSString * const CHANNEL_API_NAME = @"com.adjust.sdk/api";
         [self addValueOrEmpty:attribution.costType withKey:@"costType" toDictionary:dictionary];
         [self addNumberOrEmpty:attribution.costAmount withKey:@"costAmount" toDictionary:dictionary];
         [self addValueOrEmpty:attribution.costCurrency withKey:@"costCurrency" toDictionary:dictionary];
-        NSData *dataJsonResponse = [NSJSONSerialization dataWithJSONObject:attribution.jsonResponse
+
+        // Add nil check before serializing jsonResponse
+        if (attribution.jsonResponse != nil) {
+            NSData *dataJsonResponse = [NSJSONSerialization dataWithJSONObject:attribution.jsonResponse
                                                                    options:0
                                                                      error:nil];
-        NSString *stringJsonResponse = [[NSString alloc] initWithBytes:[dataJsonResponse bytes]
+            NSString *stringJsonResponse = [[NSString alloc] initWithBytes:[dataJsonResponse bytes]
                                                                 length:[dataJsonResponse length]
                                                               encoding:NSUTF8StringEncoding];
-        [self addValueOrEmpty:stringJsonResponse withKey:@"jsonResponse" toDictionary:dictionary];
+            [self addValueOrEmpty:stringJsonResponse withKey:@"jsonResponse" toDictionary:dictionary];
+        } else {
+            [self addValueOrEmpty:@"" withKey:@"jsonResponse" toDictionary:dictionary];
+        }
         result(dictionary);
     }];
 }
@@ -687,7 +693,7 @@ static NSString * const CHANNEL_API_NAME = @"com.adjust.sdk/api";
         if (verificationResult == nil) {
             result(dictionary);
         }
-        
+
         [self addValueOrEmpty:verificationResult.verificationStatus
                       withKey:@"verificationStatus"
                  toDictionary:dictionary];
@@ -788,7 +794,7 @@ static NSString * const CHANNEL_API_NAME = @"com.adjust.sdk/api";
         if (verificationResult == nil) {
             result(dictionary);
         }
-        
+
         [self addValueOrEmpty:verificationResult.verificationStatus
                       withKey:@"verificationStatus"
                  toDictionary:dictionary];

--- a/ios/Classes/AdjustSdkDelegate.m
+++ b/ios/Classes/AdjustSdkDelegate.m
@@ -44,7 +44,7 @@ static NSString *dartSkanUpdatedCallback = nil;
                                     methodChannel:(FlutterMethodChannel *)channel {
     dispatch_once(&onceToken, ^{
         defaultInstance = [[AdjustSdkDelegate alloc] init];
-        
+
         // do the swizzling where and if needed
         if (swizzleAttributionCallback != nil) {
             [defaultInstance swizzleCallbackMethod:@selector(adjustAttributionChanged:)
@@ -107,7 +107,7 @@ static NSString *dartSkanUpdatedCallback = nil;
     if (nil == attribution || nil == dartAttributionCallback) {
         return;
     }
-    
+
     id keys[] = {
         @"trackerToken",
         @"trackerName",
@@ -121,12 +121,18 @@ static NSString *dartSkanUpdatedCallback = nil;
         @"costCurrency",
         @"jsonResponse"
     };
-    NSData *dataJsonResponse = [NSJSONSerialization dataWithJSONObject:attribution.jsonResponse
-                                                               options:0
-                                                                 error:nil];
-    NSString *stringJsonResponse = [[NSString alloc] initWithBytes:[dataJsonResponse bytes]
-                                                            length:[dataJsonResponse length]
-                                                          encoding:NSUTF8StringEncoding];
+
+    // Add nil check before serializing jsonResponse
+    NSString *stringJsonResponse = @"";
+    if (attribution.jsonResponse != nil) {
+        NSData *dataJsonResponse = [NSJSONSerialization dataWithJSONObject:attribution.jsonResponse
+                                                                options:0
+                                                                  error:nil];
+        stringJsonResponse = [[NSString alloc] initWithBytes:[dataJsonResponse bytes]
+                                                     length:[dataJsonResponse length]
+                                                   encoding:NSUTF8StringEncoding];
+    }
+
     id values[] = {
         [self getValueOrEmpty:[attribution trackerToken]],
         [self getValueOrEmpty:[attribution trackerName]],
@@ -202,7 +208,7 @@ static NSString *dartSkanUpdatedCallback = nil;
     if (nil == eventSuccessResponseData || nil == dartEventSuccessCallback) {
         return;
     }
-    
+
     id keys[] = {
         @"message",
         @"timestamp",


### PR DESCRIPTION
### Problem
I identified a specific crash pattern affecting users who installed the previous version of the app (with the older adjust_sdk) and then updated to the latest version. These users experienced crashes due to attempts to serialize `nil` JSON responses in the Adjust SDK. They can not open the app and immediately receive a blank screen and a crash. Users who directly installed the newest app version did not report this issue.

### Solution
This PR implements nil-checking mechanisms to prevent crashes during JSON serialization:

**Added nil checks before JSON serialization:**
   - In `AdjustSdk.m`: Added conditional checks before serializing `attribution.jsonResponse`
   - In `AdjustSdkDelegate.m`: Added similar protection for JSON serialization operations
   - Ensured empty strings are used as fallbacks when nil values are encountered

Since this is a quite important bug for now, you might consider prioritizing it @uerceg 

For more implementation details, see the [commit](https://github.com/bahricanyesil/flutter_sdk/commit/84f77847a8b6f421057ae3599d68076c894ee8a4).
